### PR TITLE
Fix statutory declaration

### DIFF
--- a/diplomovka.tex
+++ b/diplomovka.tex
@@ -119,10 +119,12 @@
   odborné vedenie, metodickú pomoc a cenné rady, ktoré mi poskytol pri
   vypracovaní tejto diplomovej práce.}
 
-\TextPrehlasenia{Prehlasujem, že som svoju diplomovú prácu vypracoval samostatne
-  s~využitím informačných zdrojov, ktoré sú v~práci citované.}
+\TextPrehlasenia{Prehlasujem, že som svoju diplomovú prácu na tému
+  \textit{Scientometrická analýza Fakulty prírodných vied Univerzity sv.\,Cyrila
+    a~Metoda v~Trnave} vypracoval samostatne pod~odborným vedením svojho
+  školiteľa, s~použitím literatúry uvedenej v~zozname.}
 
-\DatumPrehlasenia{10.\,decembra 2016}
+\DatumPrehlasenia{20.\,decembra 2016}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%
@@ -162,14 +164,6 @@
 %%
 \VytvorPovinneStrany
 
-
-%%
-%%  Abstrakty
-%%
-\AbstraktyNaJednejStrane
-% \AbstraktyNaDvochStranach
-
-
 %%
 %%  Zadanie
 %%
@@ -182,10 +176,16 @@
 % \VlozZadanie{zadanie.pdf}
 
 %%
-%% Podakovanie a cestne prehlasenie
+%% Cestne prehlasenie a podakovanie
 %%
-\PodakovanieAPrehlasenie
+\PrehlasenieAPodakovanie
 % \PrehlasenieBezPodakovania
+
+%%
+%%  Abstrakty
+%%
+\AbstraktyNaJednejStrane
+% \AbstraktyNaDvochStranach
 
 %%
 %%  Obsah

--- a/ucmthesis.sty
+++ b/ucmthesis.sty
@@ -298,6 +298,83 @@ decembra\fi \space\number\year}
 
 \newcommand{\VytvorPovinneStrany}{\Dosky\TitulnaStrana}
 
+
+%%
+%%  Zadanie
+%%
+
+\newcommand{\SemVlozitZadanie}{
+\phantomsection
+\chapter*{}
+\pdfbookmark{Ofici{\'{a}}lne zadanie}{Oficialne zadanie}
+\thispagestyle{empty}
+\begin{center}
+\setlength\fboxrule{1.5pt}
+\setlength\fboxsep{8pt}
+\fbox{\textcolor{blue}{\bf Namiesto tejto strany vlo{\v{z}}te k{\'{o}}piu ofici{\'{a}}lneho (podp{\'{i}}san{\'{e}}ho)
+zadania pr{\'{a}}ce.}}
+\end{center}
+\cleardoublepage
+}
+
+\newcommand{\VlozZadanie}[1]{
+\begin{center}
+\includepdf[pages={-},pagecommand={\thispagestyle{empty}\pdfbookmark{Ofici{\'{a}}lne zadanie}{Oficialne zadane}}]{#1}
+\end{center}
+\cleardoublepage
+}
+
+
+%%
+%%  Cestne prehlasenie a podakovanie
+%%
+
+\newcommand{\PrehlasenieAPodakovanie}{
+  \thispagestyle{empty}
+  \vspace*{\fill}
+  \pdfbookmark{{\v{C}}estn{\'{e}} prehl{\'{a}}senie}{Cestne prehlasenie}
+  \NazovPovinnejCasti{\Huge {\v{C}}estn{\'{e}} prehl{\'{a}}senie}
+
+  \Prehlasenie
+
+  \vspace*{15mm}
+
+  \noindent Trnava, \DatumPrehl \hfill \makebox[50mm]{\dotfill}\\
+  \hspace*{\fill} \MenoAutora\hspace*{15mm}
+  \cleardoublepage
+
+
+  \thispagestyle{empty}
+  \vspace*{\fill}
+  \pdfbookmark{Po{\v{d}}akovanie}{Podakovanie}
+  \NazovPovinnejCasti{Po{\v{d}}akovanie}
+
+  \Podakovanie
+
+  \cleardoublepage
+}
+
+\newcommand{\PrehlasenieBezPodakovania}{
+  \vspace*{\fill}
+  \pdfbookmark{{\v{C}}estn{\'{e}} prehl{\'{a}}senie}{Cestne prehlasenie}
+  \NazovPovinnejCasti{\Huge {\v{C}}estn{\'{e}} prehl{\'{a}}senie}
+
+  \Prehlasenie
+
+  \vspace*{15mm}
+
+  \noindent Trnava, \DatumPrehl \hfill \makebox[50mm]{\dotfill}\\
+  \hspace*{\fill} \MenoAutora\hspace*{15mm}
+  \cleardoublepage
+}
+
+
+%%
+%%  Podakovanie
+%%
+
+
+
 %%
 %%  Abstrakty na jednej strane
 %%
@@ -341,75 +418,6 @@ decembra\fi \space\number\year}
 \cleardoublepage
 }
 
-
-%%
-%%  Zadanie
-%%
-
-\newcommand{\SemVlozitZadanie}{
-\phantomsection
-\chapter*{}
-\pdfbookmark{Ofici{\'{a}}lne zadanie}{Oficialne zadanie}
-\thispagestyle{empty}
-\begin{center}
-\setlength\fboxrule{1.5pt}
-\setlength\fboxsep{8pt}
-\fbox{\textcolor{blue}{\bf Namiesto tejto strany vlo{\v{z}}te k{\'{o}}piu ofici{\'{a}}lneho (podp{\'{i}}san{\'{e}}ho)
-zadania pr{\'{a}}ce.}}
-\end{center}
-\cleardoublepage
-}
-
-\newcommand{\VlozZadanie}[1]{
-\begin{center}
-\includepdf[pages={-},pagecommand={\thispagestyle{empty}\pdfbookmark{Ofici{\'{a}}lne zadanie}{Oficialne zadane}}]{#1}
-\end{center}
-\cleardoublepage
-}
-
-%%
-%%  Podakovanie a prehlasenie
-%%
-
-\newcommand{\PodakovanieAPrehlasenie}{
-\pdfbookmark{Po{\v{d}}akovanie}{Podakovanie}
-\NazovPovinnejCasti{Po{\v{d}}akovanie}
-\thispagestyle{empty}
-
-
-\Podakovanie
-
-\vspace*{\fill}
-\pdfbookmark{Prehl{\'{a}}senie}{Prehlasenie}
-\NazovPovinnejCasti{Prehl{\'{a}}senie}
-
-\Prehlasenie
-
-\vspace*{15mm}
-
-\noindent Trnava, \DatumPrehl \hfill \makebox[50mm]{\dotfill}\\
-\hspace*{\fill} \MenoAutora\hspace*{15mm}
-\cleardoublepage
-}
-
-%%
-%%  Prehlasenie bez podakovania
-%%
-
-\newcommand{\PrehlasenieBezPodekovania}{
-
-\vspace*{\fill}
-\pdfbookmark{Prehl{\'{a}}senie}{Prohlaseni}
-\NazovPovinnejCasti{\Huge Prehl{\'{a}}senie}
-
-\Prehlasenie
-
-\vspace*{15mm}
-
-\noindent Trnava, \DatumPrehl \hfill \makebox[50mm]{\dotfill}\\
-\hspace*{\fill} \MenoAutora\hspace*{15mm}
-\cleardoublepage
-}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%


### PR DESCRIPTION
The statutory declaration section has to be fixed according official guidelines; nevertheless, in the official guidelines, the thesis title should be handwritten, nevertheless it's far more elegant to typeset it in italic.
The official guidelines also do not state there should be a place, date next to the subscription, but I think that it should be there, as well as the actual student's name below the dotted line.

- [x] Refactor original template code related to *Statutory declaration* section
- [x] Fix issue #9 
- [x] Fix issue #11 
