### PR TITLE
Table caption fix (issue #5)

### DIFF
--- a/diplomovka.tex
+++ b/diplomovka.tex
@@ -46,6 +46,9 @@
 \usepackage{longtable} % balik pre tabulky presahujuce jednu stranu
                        % (potrebne pre zoznam znaceni)
 
+% balik pre postranne popisky obrazkov a tabuliek
+\usepackage[leftcaption,ragged]{sidecap}
+
 \usepackage{amsmath,amssymb,amsthm} % baliky pre matematicke vzorce
 \usepackage{natbib}    % balik pre harvardsky styl citacii
 

--- a/kapitola2.tex
+++ b/kapitola2.tex
@@ -81,8 +81,10 @@ záznamov sa znížil na 356.
 prírodných vied podľa tabuľky~\ref{tab:scopus.exauthors}.  Počet záznamov sa tak
 znížil na 329.
 
-\begin{table}
+\begin{SCtable}
 \centering\small
+\caption{Scopus -- vylúčení autori.}
+\label{tab:scopus.exauthors}
 \begin{tabular}{lc}
   \hline\noalign{\vspace{.3ex}}
   Meno autora                & Afiliácia \\[0.3ex]
@@ -99,9 +101,7 @@ znížil na 329.
   Vicente, Romana Albaladejo & -- \\[0.5ex]
   \hline
 \end{tabular}
-\caption{Scopus -- vylúčení autori.}
-\label{tab:scopus.exauthors}
-\end{table}
+\end{SCtable}
 
 Vytriedené záznamy sme uložili do formátu CSV\footnote{\uv{Comma-separated
     values} -- textový formát dát v~ktorom sú jednotlivé položky oddelené
@@ -190,7 +190,9 @@ z~databáz Scopus a WoS (označené ako \uv{\texttt{scopus~17.5.2016.csv}} a
 \uv{\texttt{scopus~17.5.2016.csv}} sme zmazali duplicitné záznamy a opravili
 chybný zápis mien podľa tabuľky \ref{tab:wos.namecorrections}.
 
-\begin{table}
+\begin{SCtable}
+\caption{Oprava chýb v~menách autorov v~súbore \uv{\texttt{scopus~17.5.2016.csv}}.}
+\label{tab:wos.namecorrections}
 \centering\small
 \begin{tabular}{ll}
   \hline\noalign{\vspace{.3ex}}
@@ -203,15 +205,15 @@ chybný zápis mien podľa tabuľky \ref{tab:wos.namecorrections}.
   Titiş        & Titiš      \\[0.5ex]
   \hline
 \end{tabular}
-\caption{Oprava chýb v~menách autorov v~súbore \uv{\texttt{scopus~17.5.2016.csv}}.}
-\label{tab:wos.namecorrections}
-\end{table}
+\end{SCtable}
 
 Pretože databáza Scopus nám umožnila odstrániť všetky záznamy z~iných fakúlt,
 súbor \uv{\texttt{scopus~17.5.2016.csv}} sme ďalej neupravovali a konečný počet
 bibliografických záznamov je 324.
 
-\begin{table}
+\begin{SCtable}
+\caption{Mená pracovníkov, ktorí nepatria do Fakulty prírodných vied.}
+\label{tab:wos.excludedstaff}
 \centering\small
 \begin{tabular}{lc}
   \hline\noalign{\vspace{.3ex}}
@@ -230,9 +232,7 @@ bibliografických záznamov je 324.
   Novakova Renata & -- \\[0.5ex]
   \hline
 \end{tabular}
-\caption{Mená pracovníkov, ktorí nepatria do Fakulty prírodných vied.}
-\label{tab:wos.excludedstaff}
-\end{table}
+\end{SCtable}
 
 WoS má veľmi obmedzené možnosti triedenia väčšieho množstva dát, napr.\,je možné
 filtrovať podľa 100 autorov (Scopus tákéto obmedzenie nepozná).  Z~týchto
@@ -253,12 +253,14 @@ z~katedier (podľa kľúčových slov).Záznamy Katedry biofyziky a Katedry odbo
 jazykovej prípravy boli z~analýzy vyňaté zahrnuté pre veľmi nízky počet dát.
 
 \begin{table}
+\caption{Rozdelenie pracovníkov do jednotlivých katedier.}
+\label{tab:staffsort}
 \centering\small
 \begin{tabular}{lllll}
   \hline\noalign{\vspace{.3ex}}
   Katedra  & Katedra        & Katedra & Katedra         & Katedry      \\
-  biológie & biotechnológii & chémie  & ekochémie       & aplikovanej  \\ 
-           &                &         & a~rádioekológie & informatiky  \\ 
+  biológie & biotechnológii & chémie  & ekochémie       & aplikovanej  \\
+           &                &         & a~rádioekológie & informatiky  \\
            &                &         &                 & a~matematiky \\[0.3ex]
   \hline\noalign{\vspace{.5ex}}
   Janeček, Štefan, Š. & Breierová      & Baran       & Babulicová & Ďurikovič   \\
@@ -281,8 +283,6 @@ jazykovej prípravy boli z~analýzy vyňaté zahrnuté pre veľmi nízky počet 
                       &                & Titiš       &            &             \\[0.5ex]
   \hline
 \end{tabular}
-\caption{Rozdelenie pracovníkov do jednotlivých katedier.}
-\label{tab:staffsort}
 \end{table}
 
 

--- a/kapitola3.tex
+++ b/kapitola3.tex
@@ -252,6 +252,8 @@ Kréte. \citep{LAZARIDIS2010}
 
 \begin{table}
 \centering\small
+\caption{Základné citačné informácie.}
+\label{tab:citation.info}
 \begin{tabular}{llccccc}
   \hline\noalign{\vspace{.3ex}}
   Dátový súbor & Citačný  & Počet   & Počet   & Vek      & Citácie/ & Citácie/ \\
@@ -271,13 +273,13 @@ Kréte. \citep{LAZARIDIS2010}
                  & WoS    &  -- &     -- & -- &  --    & --   \\[0.5ex]
   \hline
 \end{tabular}
-\caption{Základné citačné informácie.}
-\label{tab:citation.info}
 \end{table}
 
 
 \begin{table}
 \centering\small
+\caption{Pokračovanie základných citačných informácii.}
+\label{tab:citation.info2}
 \begin{tabular}{llccc}
   \hline\noalign{\vspace{.3ex}}
   Dátový súbor & Citačný  & Citácie/ & Články/ & Autori/ \\
@@ -297,12 +299,12 @@ Kréte. \citep{LAZARIDIS2010}
                  & WoS    &  --    & --    & --   \\[0.5ex]
   \hline
 \end{tabular}
-\caption{Pokračovanie základných citačných informácii.}
-\label{tab:citation.info2}
 \end{table}
 
 \begin{table}
 \centering\small
+\caption{Citačné indikátory.}
+\label{tab:citation.indicators}
 \begin{tabular}{llcccccccc}
   \hline\noalign{\vspace{.3ex}}
   Dátový súbor & Citačný  & $h$ & $g$ & $h^{\mathrm{c}}$ & $h_{\mathrm{I}}$ & $h_{\mathrm{I, norm}}$ & AWCR & AW    & AWCR/ \\
@@ -322,12 +324,12 @@ Kréte. \citep{LAZARIDIS2010}
                  & WoS    & -- & -- & -- &  --  & -- &  --    & --    &  --    \\[0.5ex]
   \hline
 \end{tabular}
-\caption{Citačné indikátory.}
-\label{tab:citation.indicators}
 \end{table}
 
 \begin{table}
 \centering\small
+\caption{Pokračovanie citačných indikátorov.}
+\label{tab:citation.indicators2}
 \begin{tabular}{llccccc}
   \hline\noalign{\vspace{.3ex}}
   Dátový súbor & Citačný  & $e$ & $h_{\mathrm{m}}$ & Citácia/   & Pokrytie        & Pokrytie        \\
@@ -347,8 +349,6 @@ Kréte. \citep{LAZARIDIS2010}
                  & WoS    & --    & --    & --    & -- & -- \\[0.5ex]
   \hline
 \end{tabular}
-\caption{Pokračovanie citačných indikátorov.}
-\label{tab:citation.indicators2}
 \end{table}
 
 

--- a/ucmthesis.sty
+++ b/ucmthesis.sty
@@ -153,8 +153,9 @@ decembra\fi \space\number\year}
 %
 %  Nastavenie popiskov obrazkov a tabuliek
 %
-\captionsetup{labelfont=bf}
+\captionsetup{font=small,labelfont=bf}
 \captionsetup[figure]{name=Obr{\'{a}}zok}
+\captionsetup[table]{skip=2pt}
 
 %%
 %%  Predefinovanie cleardoublepage tak, aby pri obojstrannej tlaci nebola na


### PR DESCRIPTION
I moved table captions above tables as defined by the guidelines (as reported in issue #5).  For the narrow tables I've decided to place caption on the left side using 'sidecap' package.  It looks much more fancier.

- [x] Move table caption to the top of the table.
- [x] Set skip for the table captions to 2pt.
- [x] Move captions for the narrow tables to the left side.