### PR TITLE
Enhance typography of the tables

### DIFF
--- a/diplomovka.tex
+++ b/diplomovka.tex
@@ -46,6 +46,8 @@
 \usepackage{longtable} % balik pre tabulky presahujuce jednu stranu
                        % (potrebne pre zoznam znaceni)
 
+\usepackage{booktabs}  % balík pre vysadzanie profesionalnych tabuliek
+
 % balik pre postranne popisky obrazkov a tabuliek
 \usepackage[leftcaption,ragged]{sidecap}
 

--- a/kapitola2.tex
+++ b/kapitola2.tex
@@ -86,9 +86,9 @@ znížil na 329.
 \caption{Scopus -- vylúčení autori.}
 \label{tab:scopus.exauthors}
 \begin{tabular}{lc}
-  \hline\noalign{\vspace{.3ex}}
+  \toprule\noalign{\vspace{.3ex}}
   Meno autora                & Afiliácia \\[0.3ex]
-  \hline\noalign{\vspace{.5ex}}
+  \midrule\noalign{\vspace{.5ex}}
   Bezáková, Zuzana           & -- \\
   Ferriero, Giorgio          & -- \\
   Halenár, Robert            & -- \\
@@ -99,7 +99,7 @@ znížil na 329.
   Rovenský, Jozef A.         & -- \\
   Trnka, Andrej              & -- \\
   Vicente, Romana Albaladejo & -- \\[0.5ex]
-  \hline
+  \bottomrule
 \end{tabular}
 \end{SCtable}
 
@@ -195,15 +195,15 @@ chybný zápis mien podľa Tabuľky \ref{tab:wos.namecorrections}.
 \label{tab:wos.namecorrections}
 \centering\small
 \begin{tabular}{ll}
-  \hline\noalign{\vspace{.3ex}}
+  \toprule\noalign{\vspace{.3ex}}
   Pôvodné meno & Opravené meno \\[0.3ex]
-  \hline\noalign{\vspace{.5ex}}
+  \midrule\noalign{\vspace{.5ex}}
   Boa          & Boča       \\
   Boça         & Boča       \\
   Horváthovái  & Horváthová \\
   Oturdík      & Šturdík    \\
   Titiş        & Titiš      \\[0.5ex]
-  \hline
+  \bottomrule
 \end{tabular}
 \end{SCtable}
 
@@ -216,9 +216,9 @@ bibliografických záznamov je 324.
 \label{tab:wos.excludedstaff}
 \centering\small
 \begin{tabular}{lc}
-  \hline\noalign{\vspace{.3ex}}
+  \toprule\noalign{\vspace{.3ex}}
   Meno            & Fakulta \\[0.3ex]
-  \hline\noalign{\vspace{.5ex}}
+  \midrule\noalign{\vspace{.5ex}}
   Balaz           & -- \\
   Balazova        & -- \\
   Bezakova        & -- \\
@@ -230,7 +230,7 @@ bibliografických záznamov je 324.
   Halenar         & -- \\
   Mura            & -- \\[1ex]
   Novakova Renata & -- \\[0.5ex]
-  \hline
+  \bottomrule
 \end{tabular}
 \end{SCtable}
 
@@ -257,12 +257,12 @@ jazykovej prípravy boli z~analýzy vyňaté zahrnuté pre veľmi nízky počet 
 \label{tab:staffsort}
 \centering\small
 \begin{tabular}{lllll}
-  \hline\noalign{\vspace{.3ex}}
+  \toprule\noalign{\vspace{.3ex}}
   Katedra  & Katedra        & Katedra & Katedra         & Katedry      \\
   biológie & biotechnológii & chémie  & ekochémie       & aplikovanej  \\
            &                &         & a~rádioekológie & informatiky  \\
            &                &         &                 & a~matematiky \\[0.3ex]
-  \hline\noalign{\vspace{.5ex}}
+  \midrule\noalign{\vspace{.5ex}}
   Janeček, Štefan, Š. & Breierová      & Baran       & Babulicová & Ďurikovič   \\
   Godány              & Faragó         & Bednárová   & Fargašová  & Gudába      \\
   Preťová             & Gazdík         & Beinrohr    & Horník     & Hostovecký  \\
@@ -281,7 +281,7 @@ jazykovej prípravy boli z~analýzy vyňaté zahrnuté pre veľmi nízky počet 
                       &                & Rabara      &            &             \\
                       &                & Rimančík    &            &             \\
                       &                & Titiš       &            &             \\[0.5ex]
-  \hline
+  \bottomrule
 \end{tabular}
 \end{table}
 

--- a/kapitola3.tex
+++ b/kapitola3.tex
@@ -256,10 +256,10 @@ Kréte. \citep{LAZARIDIS2010}
 \caption{Základné citačné informácie.}
 \label{tab:citation.info}
 \begin{tabular}{llccccc}
-  \hline\noalign{\vspace{.3ex}}
+  \toprule\noalign{\vspace{.3ex}}
   Dátový súbor & Citačný  & Počet   & Počet   & Vek      & Citácie/ & Citácie/ \\
                & register & článkov & citácii & v~rokoch & rok      & článok   \\[0.3ex]
-  \hline\noalign{\vspace{.5ex}}
+  \midrule\noalign{\vspace{.5ex}}
   Celá fakulta   & Scopus & 324 & 2\,524 & 16 & 157,75 & 7,79 \\
                  & WoS    & 288 & 1\,712 & 16 & 107,00 & 5,94 \\[1ex]
   Biológia       & Scopus &  28 &    265 & 16 &  16,56 & 9,46 \\
@@ -272,7 +272,7 @@ Kréte. \citep{LAZARIDIS2010}
                  & WoS    &  33 &    207 & 12 &  17,25 & 6,27 \\[1ex]
   Informatika    & Scopus &  18 &     28 & 14 &   2,00 & 1,56 \\
                  & WoS    &  -- &     -- & -- &  --    & --   \\[0.5ex]
-  \hline
+  \bottomrule
 \end{tabular}
 \end{table}
 
@@ -282,10 +282,10 @@ Kréte. \citep{LAZARIDIS2010}
 \caption{Pokračovanie základných citačných informácii.}
 \label{tab:citation.info2}
 \begin{tabular}{llccc}
-  \hline\noalign{\vspace{.3ex}}
+  \toprule\noalign{\vspace{.3ex}}
   Dátový súbor & Citačný  & Citácie/ & Články/ & Autori/ \\
                & register & autor    & autor   & článok  \\[0.3ex]
-  \hline\noalign{\vspace{.5ex}}
+  \midrule\noalign{\vspace{.5ex}}
   Celá fakulta   & Scopus & 662,43 & 83,89 & 4,78 \\
                  & WoS    & 425,01 & 84,58 & 4,70 \\[1ex]
   Biológia       & Scopus &  88,59 &  9,23 & 3,93 \\
@@ -298,7 +298,7 @@ Kréte. \citep{LAZARIDIS2010}
                  & WoS    &  48,45 &  7,77 & 4,97 \\[1ex]
   Informatika    & Scopus &  11,67 &  7,95 & 2,78 \\
                  & WoS    &  --    & --    & --   \\[0.5ex]
-  \hline
+  \bottomrule
 \end{tabular}
 \end{table}
 
@@ -307,10 +307,10 @@ Kréte. \citep{LAZARIDIS2010}
 \caption{Citačné indikátory.}
 \label{tab:citation.indicators}
 \begin{tabular}{llcccccccc}
-  \hline\noalign{\vspace{.3ex}}
+  \toprule\noalign{\vspace{.3ex}}
   Dátový súbor & Citačný  & $h$ & $g$ & $h^{\mathrm{c}}$ & $h_{\mathrm{I}}$ & $h_{\mathrm{I, norm}}$ & AWCR & AW    & AWCR/ \\
                & register &     &     &                  &                  &                        &       & index & autor \\[0.3ex]
-  \hline\noalign{\vspace{.5ex}}
+  \midrule\noalign{\vspace{.5ex}}
   Celá fakulta   & Scopus & 26 & 36 & 21 & 4,76 & 12 & 488,95 & 22,11 & 127,24 \\
                  & WoS    & 22 & 31 & 20 & 4,44 & 10 & 400,05 & 20,00 &  95,77 \\[1ex]
   Biológia       & Scopus & 10 & 16 &  8 & 2,44 &  6 &  46,66 &  6,83 &  13,00 \\
@@ -323,7 +323,7 @@ Kréte. \citep{LAZARIDIS2010}
                  & WoS    &  8 & 12 &  8 & 1,64 &  4 &  54,52 &  7,38 &  14,15 \\[1ex]
   Informatika    & Scopus &  3 &  4 &  2 & 1,00 &  2 &   3,99 &  2,00 &   1,61 \\
                  & WoS    & -- & -- & -- &  --  & -- &  --    & --    &  --    \\[0.5ex]
-  \hline
+  \bottomrule
 \end{tabular}
 \end{table}
 
@@ -332,10 +332,10 @@ Kréte. \citep{LAZARIDIS2010}
 \caption{Pokračovanie citačných indikátorov.}
 \label{tab:citation.indicators2}
 \begin{tabular}{llccccc}
-  \hline\noalign{\vspace{.3ex}}
+  \toprule\noalign{\vspace{.3ex}}
   Dátový súbor & Citačný  & $e$ & $h_{\mathrm{m}}$ & Citácia/   & Pokrytie        & Pokrytie        \\
                & register &     &                  & autora/rok & $h$-indexu (\%) & $g$-indexu (\%) \\[0.3ex]
-  \hline\noalign{\vspace{.5ex}}
+  \midrule\noalign{\vspace{.5ex}}
   Celá fakulta   & Scopus & 20,62 & 13,62 & 41,40 & 44 & 53 \\
                  & WoS    & 18,71 & 10,67 & 26,56 & 49 & 58 \\[1ex]
   Biológia       & Scopus & 10,86 &  4,94 &  5,53 & 82 & 97 \\
@@ -348,7 +348,7 @@ Kréte. \citep{LAZARIDIS2010}
                  & WoS    &  8,12 &  4,18 &  4,03 & 63 & 76 \\[1ex]
   Informatika    & Scopus &  3,32 &  1,42 &  0,83 & 71 & 82 \\
                  & WoS    & --    & --    & --    & -- & -- \\[0.5ex]
-  \hline
+  \bottomrule
 \end{tabular}
 \end{table}
 


### PR DESCRIPTION
I added the 'booktabs' package that allows to replace \hline with \toprule, \midrule and \bottomrule.  By default are top and bottom rules thicker and mid rule normal thickness.  I'm going to keep it that way,
although the request for enhancement #8 suggested complete opposite, because it looks fancy as well.  We don't have to copy the Springer's style for all cost.

- [x] Import 'booktabs' package.
- [x] Alter code of all tables to use the package.